### PR TITLE
Other: Added SAP Start as central entry point

### DIFF
--- a/docs/10-what-is/supported-solutions-and-use-cases-758209c.md
+++ b/docs/10-what-is/supported-solutions-and-use-cases-758209c.md
@@ -4,7 +4,7 @@
 
 Review the list of the supported solutions and use cases in SAP Task Center.
 
-**Supported Use Cases \(Task Types\) for SAP Task Center Web App and Task Center in the SAP Mobile Start Mobile App**
+**Supported Use Cases \(Task Types\) for SAP Task Center Web App, SAP Start and Task Center in the SAP Mobile Start Mobile App**
 
 
 <table>

--- a/docs/30-initial-setup/initial-setup-8347694.md
+++ b/docs/30-initial-setup/initial-setup-8347694.md
@@ -77,11 +77,13 @@ For the integration with SAP Advanced Financial Closing, SAP Build Process Autom
 
 ### Verify Your Central Point of Entry for Accessing Applications
 
-You have purchased at least one of the following central points of entry for accessing apps and it is available in your global account.
+You are entitled to use at least one of the following central points of entry for accessing apps and it is available in your global account.
 
 -   SAP Build Work Zone, standard edition, formerly known as SAP Launchpad service
 
     The SAP Build Work Zone, standard edition is also available in free tier. For more information, see [Initial Setup](https://help.sap.com/viewer/8c8e1958338140699bd4811b37b82ece/Cloud/en-US/fd79b232967545569d1ae4d8f691016b.html) and [Using an Account with a Free Service Plan](https://help.sap.com/docs/Launchpad_Service/8c8e1958338140699bd4811b37b82ece/1868e0dd101a4aa78b75e49ab46c992a.html).
+
+-   SAP Start
 
 -   SAP Build Work Zone, advanced edition
 

--- a/docs/70-using-the-web-app/to-dos-in-sap-start-8549f76.md
+++ b/docs/70-using-the-web-app/to-dos-in-sap-start-8549f76.md
@@ -1,15 +1,15 @@
 <!-- loio8549f76ef05d4d8bb9f5def6b03df0bf -->
 
-# To Dos in SAP Start
+# To-Dos in SAP Start
 
-Process your most recent tasks from the *To Dos* section in SAP Start.
+Process your most recent tasks from the *To-Dos* section in SAP Start.
 
-In the *To Dos* section of SAP Start, you can find your most recent tasks \(as received in your task list\), along with details of the task and action buttons. Processing a task from the card in SAP Start updates its status also in the SAP Task Center task list, and the respective task provider. For more information, see [To Dos](https://help.sap.com/docs/start/sap-start/to-dos).
+In the *To-Dos* section of SAP Start, you can find your most recent tasks \(as received in your task list\), along with details of the task and action buttons. Processing a task from the card in SAP Start updates its status also in the SAP Task Center task list, and the respective task provider. For more information, see [To-Dos](https://help.sap.com/docs/start/sap-start/to-dos).
 
 **Related Information**  
 
 
-[Configure To Dos in SAP Start](../40-administration/configure-to-dos-in-sap-start-c05ad6f.md "The To Dos in SAP Start are cards, visualizing the most important information of the latest tasks in the SAP Task Center task list, allowing users to access and process their tasks from the SAP Start user interface.")
+[Configure To-Dos in SAP Start](../40-administration/configure-to-dos-in-sap-start-c05ad6f.md "The To-Dos in SAP Start are cards, visualizing the most important information of the latest tasks in the SAP Task Center task list, allowing users to access and process their tasks from the SAP Start user interface.")
 
 [Supported Solutions and Use Cases](../10-what-is/supported-solutions-and-use-cases-758209c.md "Review the list of the supported solutions and use cases in SAP Task Center.")
 


### PR DESCRIPTION
SAP Start is a valid Central Entry Point for SAP Task Center.
https://help.sap.com/docs/start/sap-start/what-is-sap-start

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

